### PR TITLE
Update Windows CI job

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,16 +9,18 @@ jobs:
     runs-on: windows-2022
 
     env:
+      CARGO_INCREMENTAL: 0
+
       ffmpeg_ver: "6.0"
       ffmpeg_path: "C:/ffmpeg"
-      vsynth_ver: "R63"
+      vsynth_ver: "R66"
       vsynth_path: "C:/Program Files/Vapoursynth"
 
     steps:
       - name: Python 3 setup
         uses: actions/setup-python@v4
         with:
-          python-version: '~3.10'
+          python-version: '~3.12'
           architecture: x64
 
       - name: NASM setup
@@ -41,7 +43,7 @@ jobs:
 
       - name: VapourSynth cache
         id: cache-vsynth
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.vsynth_path }}
           key: vsynth-${{ env.vsynth_ver }}
@@ -54,28 +56,17 @@ jobs:
           Invoke-WebRequest "$uri" -OutFile "$tempFile" -TimeoutSec 10
           7z x -y -o"$env:vsynth_path" "$tempFile"
 
-      - uses: actions/checkout@v3
-
-      - name: Package cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry
-            target
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
 
       - name: Av1an build
-        env:
-          CARGO_TERM_COLOR: always
-        run: cargo build -rv
+        run: cargo build --release
 
       - name: Create prerelease
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ github.token }}
-          automatic_release_tag: latest
           prerelease: true
-          draft: false
+          tag_name: latest
           files: target/release/av1an.exe
+          fail_on_unmatched_files: true
+


### PR DESCRIPTION
- Update multiple actions to Node 20
- Switch to maintained softprops/action-gh-release
- Update to VS R66 and Python 3.12
- Use Swatinem/rust-cache instead of manual caching